### PR TITLE
change st.cache to st.cache_data

### DIFF
--- a/streamlit_cookies_manager/encrypted_cookie_manager.py
+++ b/streamlit_cookies_manager/encrypted_cookie_manager.py
@@ -11,7 +11,7 @@ from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from streamlit_cookies_manager import CookieManager
 
 
-@st.cache
+@st.cache_data
 def key_from_parameters(salt: bytes, iterations: int, password: str):
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),


### PR DESCRIPTION
Fix the `st.cache` is deprecated and will be removed soon. Please use one of Streamlit's new
caching commands, `st.cache_data` or `st.cache_resource`